### PR TITLE
Update deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,26 +2,26 @@
 
 
 [[projects]]
-  digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
-  version = "v1.1.1"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
+  digest = "1:239c4c7fd2159585454003d9be7207167970194216193a8a210b8d29576f19c9"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -31,24 +31,16 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
-
-[[projects]]
-  branch = "master"
-  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "UT"
-  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
@@ -63,31 +55,20 @@
   version = "v0.2.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:86c1210529e69d69860f2bb3ee9ccce0b595aa3f9165e7dd1388e5c612915888"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "UT"
-  revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
-
-[[projects]]
-  digest = "1:8eb1de8112c9924d59bf1d3e5c26f5eaa2bfc2a5fcbb92dc1c2e4546d695f277"
+  digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
-  version = "v0.3.6"
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
 
 [[projects]]
-  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
+  digest = "1:f5a2051c55d05548d2d4fd23d244027b59fbd943217df8aa3b5e170ac2fd6e1b"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
-  version = "v1.1.5"
+  revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
+  version = "v1.1.6"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -106,22 +87,6 @@
   version = "1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = "UT"
-  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
-
-[[projects]]
-  digest = "1:0e7775ebbcf00d8dd28ac663614af924411c868dca3d5aa762af0fae3808d852"
-  name = "github.com/peterbourgon/diskv"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
-  version = "v2.0.1"
-
-[[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -131,15 +96,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:05ef6e1391a5b99e8c004a126bc23a207fdccc6ff5c4c175a791bf4882595379"
+  digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "9eb0be3963eaeb646c9a9b6d11f3da2b249bb2ca"
+  revision = "e1dfcc566284e143ba8f9afbb3fa563f2a0d212b"
 
 [[projects]]
   branch = "master"
-  digest = "1:f7171db635740bd80e33845acf90ca909ff7ecb89967ec1272d8cd01f3f8d1d7"
+  digest = "1:b9bf9ddb713916ca0fe4630b135cc937c81a00378a97083a906c9669d56ab23f"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -150,38 +115,40 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "f4e77d36d62c17c2336347bb2670ddbd02d092b7"
 
 [[projects]]
   branch = "master"
-  digest = "1:0142ef85bbc356750e329654ef29734ff05bd70ec9d8c1f46e39a3e97683318f"
+  digest = "1:9927d6aceb89d188e21485f42a7a254e67e6fdcf4260aba375fe18e3c300dfb4"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "8f65e3013ebad444f13bc19536f7865efc793816"
+  revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
 
 [[projects]]
   branch = "master"
-  digest = "1:f343f077a5b0bc3a3788b3a04e24dd417e3e25b2acb529c413e212d2c42416ef"
+  digest = "1:646036a04e163f383d101f40e36fd3354676c7dcccc226d825200a6b9509727a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "62eef0e2fa9b2c385f7b2778e763486da6880d37"
+  revision = "a5b02f93d862f065920dd6a40dddc66b60d0dec4"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -194,8 +161,8 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -203,10 +170,10 @@
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
-  digest = "1:08206298775e5b462e6c0333f4471b44e63f1a70e42952b6ede4ecc9572281eb"
+  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -218,8 +185,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -230,23 +197,23 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:2d2f8ae5a583a56906f10cfa3784b0bf7376d0069765fb438fa0736d266a6439"
+  digest = "1:3d206da0c5871a719863cbf3a2d44fa5c0a77670491c19e2274b05799e84879a"
   name = "k8s.io/api"
   packages = [
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
@@ -258,15 +225,20 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -275,11 +247,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "b7bd5f2d334ce968edc54f5fdb2ac67ce39c56d5"
+  revision = "61630f889b3c3efb8c3a4ba377da1a421d9ff6ce"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b2cfe244b03da212f079df14c605a5b11f81172106320f1cf415fc49dff74ebf"
+  branch = "release-1.13"
+  digest = "1:f7b5be884005454ed66a2baf43f799c81f36655fe68fb12503174212e3d1d3ec"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -319,20 +291,20 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "d4f83ca2e2604a4c3444295a8aca957c3a784f06"
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
 
 [[projects]]
-  digest = "1:113d81649dbf825c3761f4b032aa8f29c0a5f9893251185398091f7882619092"
+  digest = "1:973c1068749fb3e9549fdaad5ed9d301d7fcf0b5239f021b4fbbfbae01207e5b"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "kubernetes",
     "kubernetes/scheme",
-    "kubernetes/typed/admissionregistration/v1alpha1",
     "kubernetes/typed/admissionregistration/v1beta1",
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1beta1",
     "kubernetes/typed/authorization/v1",
@@ -344,15 +316,20 @@
     "kubernetes/typed/batch/v1beta1",
     "kubernetes/typed/batch/v2alpha1",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1",
     "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/extensions/v1beta1",
     "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1beta1",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1beta1",
     "kubernetes/typed/policy/v1beta1",
     "kubernetes/typed/rbac/v1",
     "kubernetes/typed/rbac/v1alpha1",
     "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1beta1",
     "kubernetes/typed/settings/v1alpha1",
@@ -379,19 +356,27 @@
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
+    "util/keyutil",
   ]
   pruneopts = "UT"
-  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
-  version = "v9.0.0"
+  revision = "6ee68ca5fd8355d024d02f9db0b3b667e8357a0f"
+  version = "v11.0.0"
 
 [[projects]]
-  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
+  digest = "1:c696379ad201c1e86591785579e16bf6cf886c362e9a7534e8eb0d1028b20582"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
+  revision = "e531227889390a39d9533dde61f590fe9f4b0035"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8b40227d4bf8b431fdab4f9026e6e346f00ac3be5662af367a183f78c57660b3"
+  name = "k8s.io/utils"
+  packages = ["integer"]
+  pruneopts = "UT"
+  revision = "8fab8cb257d50c8cf94ec9771e74826edbb68fb5"
 
 [[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,19 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "k8s.io/api"
+  branch = "release-1.13"
+
+[[constraint]]
+  name = "k8s.io/apimachinery"
+  branch = "release-1.13"
+
+[[constraint]]
+  name = "k8s.io/klog"
+  branch = "release-1.13"
+
+[[constraint]]
+  name = "sigs.k8s.io/yaml"
+  branch = "release-1.13"

--- a/lib/module.nix
+++ b/lib/module.nix
@@ -35,8 +35,7 @@ in
     };
 
     version = mkOption {
-      type = enum [ "1.11.0" "1.11.1" ];
-      default = "1.11.1";
+      type = str;
       description = "Kubernetes version to apply manifest validation against.";
     };
 

--- a/lib/schemas/default.nix
+++ b/lib/schemas/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "kubernetes-schemas-${version}";
-  version = "c7672fd48e1421f0060dd54b6620baa2ab7224ba";
+  version = "8aa572595b98d73b2b9415ca576f78e163381b10";
 
   src = fetchFromGitHub {
     owner = "garethr";
     repo = "kubernetes-json-schema";
     rev = version;
-    sha256 = "0picr3wvjx4qv158jy4f60pl225rm4mh0l97pf8nqi9h9x4x888p";
+    sha256 = "0fxnx0p9dq5rrbg64d8m13m2w31kkyzbiy064rl3ka46bcawzq2z";
   };
 
   phases = [ "installPhase" ];

--- a/nix-packaging/deps.nix
+++ b/nix-packaging/deps.nix
@@ -1,21 +1,21 @@
 # file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
 [
   {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
     goPackagePath  = "github.com/gogo/protobuf";
     fetch = {
       type = "git";
       url = "https://github.com/gogo/protobuf";
-      rev =  "636bf0302bc95575d69441b25a2603156ffdddf1";
-      sha256 = "1525pq7r6h3s8dncvq8gxi893p2nq8dxpzvq0nfl5b4p6mq0v1c2";
-    };
-  }
-  {
-    goPackagePath  = "github.com/golang/glog";
-    fetch = {
-      type = "git";
-      url = "https://github.com/golang/glog";
-      rev =  "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
-      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+      rev =  "ba06b47c162d49f2af050fb4c75bcbc86a159d5c";
+      sha256 = "06yqa6h0kw3gr5pc3qmas7f7435a96zf7iw7p0l00r2hqf6fqq6m";
     };
   }
   {
@@ -23,17 +23,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev =  "aa810b61a9c79d51363740d207bb46cf8e620ed5";
-      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
-    };
-  }
-  {
-    goPackagePath  = "github.com/google/btree";
-    fetch = {
-      type = "git";
-      url = "https://github.com/google/btree";
-      rev =  "4030bb1f1f0c35b30ca7009e9ebd06849dd45306";
-      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+      rev =  "b5d812f8a3706043e23a9cd5babf2e5423744d30";
+      sha256 = "15am4s4646qy6iv0g3kkqq52rzykqjhm4bf08dk0fy2r58knpsyl";
     };
   }
   {
@@ -41,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/google/gofuzz";
-      rev =  "24818f796faf91cd76ec7bddd72458fbced7a6c1";
-      sha256 = "0cq90m2lgalrdfrwwyycrrmn785rgnxa3l3vp9yxkvnv88bymmlm";
+      rev =  "f140a6486e521aad38f5917de355cbf147cc0496";
+      sha256 = "0qz439qvccm91w0mmjz4fqgx48clxdwagkvvx89cr43q1d4iry36";
     };
   }
   {
@@ -55,21 +46,12 @@
     };
   }
   {
-    goPackagePath  = "github.com/gregjones/httpcache";
-    fetch = {
-      type = "git";
-      url = "https://github.com/gregjones/httpcache";
-      rev =  "c63ab54fda8f77302f8d414e19933f2b6026a089";
-      sha256 = "0g5apnxhjj4w1gsa7mh93dqmd8bw708gabnaqpvy3gb62whfnm50";
-    };
-  }
-  {
     goPackagePath  = "github.com/imdario/mergo";
     fetch = {
       type = "git";
       url = "https://github.com/imdario/mergo";
-      rev =  "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4";
-      sha256 = "1lbzy8p8wv439sqgf0n21q52flf2wbamp6qa1jkyv6an0nc952q7";
+      rev =  "7c29201646fa3de8506f701213473dd407f19646";
+      sha256 = "05ir0jj74w0yfi1lrhjd97v759in1dpsma64cgmbiqvyp6hfmmf8";
     };
   }
   {
@@ -77,8 +59,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/json-iterator/go";
-      rev =  "1624edc4454b8682399def8740d46db5e4362ba4";
-      sha256 = "11wn4hpmrs8bmpvd93wqk49jfbbgylakhi35f9k5qd7jd479ci4s";
+      rev =  "0ff49de124c6f76f8494e194af75bde0f1a49a29";
+      sha256 = "08caswxvdn7nvaqyj5kyny6ghpygandlbw9vxdj7l5vkp7q0s43r";
     };
   }
   {
@@ -100,24 +82,6 @@
     };
   }
   {
-    goPackagePath  = "github.com/petar/GoLLRB";
-    fetch = {
-      type = "git";
-      url = "https://github.com/petar/GoLLRB";
-      rev =  "53be0d36a84c2a886ca057d34b6aa4468df9ccb4";
-      sha256 = "01xp3lcamqkvl91jg6ly202gdsgf64j39rkrcqxi6v4pbrcv7hz0";
-    };
-  }
-  {
-    goPackagePath  = "github.com/peterbourgon/diskv";
-    fetch = {
-      type = "git";
-      url = "https://github.com/peterbourgon/diskv";
-      rev =  "5f041e8faa004a95c88a202771f4cc3e991971e6";
-      sha256 = "1mxpa5aad08x30qcbffzk80g9540wvbca4blc1r2qyzl65b8929b";
-    };
-  }
-  {
     goPackagePath  = "github.com/spf13/pflag";
     fetch = {
       type = "git";
@@ -131,8 +95,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "9eb0be3963eaeb646c9a9b6d11f3da2b249bb2ca";
-      sha256 = "1iq3w7kykjaan7bblr3jj50vvxl4bs91s5x81gspllkpn40ikx2h";
+      rev =  "e1dfcc566284e143ba8f9afbb3fa563f2a0d212b";
+      sha256 = "1ch2f34fk4ma0v8rs9v51qyhdl7w3sllh39dwy4vjks5hkqz1fj2";
     };
   }
   {
@@ -140,8 +104,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev =  "adae6a3d119ae4890b46832a2e88a95adc62b8e7";
-      sha256 = "1fx860zsgzqk28j7lmp96qsfrgb0kzbfjvr294hywswcbwdwkb01";
+      rev =  "f4e77d36d62c17c2336347bb2670ddbd02d092b7";
+      sha256 = "0avjnglqqg9ya0cbhp23m4namykii219kxjywxn4cd7pfcc5arha";
     };
   }
   {
@@ -149,8 +113,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/oauth2";
-      rev =  "8f65e3013ebad444f13bc19536f7865efc793816";
-      sha256 = "1var9w8l5sj2zkxxm11c5cfagajmf55n2i6s2b5md5aj5fgg6x37";
+      rev =  "9f3314589c9a9136388751d9adae6b0ed400978a";
+      sha256 = "13rr34jmgisgy8mc7yqz3474w4qbs01gz4b7zrgkvikdv4a6py3h";
     };
   }
   {
@@ -158,8 +122,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "62eef0e2fa9b2c385f7b2778e763486da6880d37";
-      sha256 = "0mslbflrh422mcfg2hs2q1xwm3xwd5prn597w7xqhi3s41mx1vs4";
+      rev =  "a5b02f93d862f065920dd6a40dddc66b60d0dec4";
+      sha256 = "08x9lszx1bwgv8bsfskqx200kqbaa542kyzli88zfxnc61smgksm";
     };
   }
   {
@@ -167,8 +131,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
-      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+      rev =  "342b2e1fbaa52c93f31447ad2c6abc048c63e475";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
     };
   }
   {
@@ -176,8 +140,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/time";
-      rev =  "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd";
-      sha256 = "0yqnxsrarjk4qkda8kcxzmk7y90kkkxzx9iwryzrk7bzs87ky3xc";
+      rev =  "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef";
+      sha256 = "1f5nkr4vys2vbd8wrwyiq2f5wcaahhpxmia85d1gshcbqjqf8dkb";
     };
   }
   {
@@ -185,8 +149,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/appengine";
-      rev =  "4a4468ece617fc8205e99368fa2200e9d1fad421";
-      sha256 = "13cyhqwmvc2nia4ssdwwdzscq52aj3z9zjikx17wk4kb0j8vr370";
+      rev =  "54a98f90d1c46b7731eb8fb305d2a321c30ef610";
+      sha256 = "0l7mkdnwhidv8m686x432vmx8z5nqcrr9f46ddgvrxbh4wvyfcll";
     };
   }
   {
@@ -203,8 +167,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/go-yaml/yaml";
-      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
-      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+      rev =  "51d6538a90f86fe93ac480b35f37b2be17fef232";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
     };
   }
   {
@@ -212,8 +176,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/kubernetes/api";
-      rev =  "b7bd5f2d334ce968edc54f5fdb2ac67ce39c56d5";
-      sha256 = "1yfv1iq3gp6w1vbfjn8m4yyrnnpsbfcqvgzrhckrj67vr6n2wimd";
+      rev =  "61630f889b3c3efb8c3a4ba377da1a421d9ff6ce";
+      sha256 = "0l8bqphfs865zqhzrwca59fnskp4bd0r8wrr0jh2p2g7xcn6z3r1";
     };
   }
   {
@@ -221,8 +185,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/kubernetes/apimachinery";
-      rev =  "d4f83ca2e2604a4c3444295a8aca957c3a784f06";
-      sha256 = "1b37zgvv3kgw06wwx4npl185pvzqjggfln73mdwmsvfphh0lbqp8";
+      rev =  "86fb29eff6288413d76bd8506874fddd9fccdff0";
+      sha256 = "18kgpzf0yxwrzxrcgm2iafdy5k0vnarpx50am9dfxaxm6ln7z1kz";
     };
   }
   {
@@ -230,8 +194,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/kubernetes/client-go";
-      rev =  "1638f8970cefaa404ff3a62950f88b08292b2696";
-      sha256 = "1xs77mny6226q70c5crvcnapb0shgcapywk8pkr5pdl32nlm4hvr";
+      rev =  "6ee68ca5fd8355d024d02f9db0b3b667e8357a0f";
+      sha256 = "006007k55b5q95fa0vih4bprwvx5sk4a5chvsn46baqa5znphyn1";
     };
   }
   {
@@ -239,8 +203,17 @@
     fetch = {
       type = "git";
       url = "https://github.com/kubernetes/klog";
-      rev =  "a5bc97fbc634d635061f3146511332c7e313a55a";
-      sha256 = "1yibjv5mg5n3lqg0xg3llj4csj7fkz03q7wczd4xfkk3mn2cjj3g";
+      rev =  "e531227889390a39d9533dde61f590fe9f4b0035";
+      sha256 = "05lp8ddqnbypgszv3ra7x105qpr8rr1g4rk2148wcmgfjrfhw437";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/utils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/utils";
+      rev =  "8fab8cb257d50c8cf94ec9771e74826edbb68fb5";
+      sha256 = "0ckkl9zj8c0p5csfgsnvgb3vm91l2zgxgxhbjcf3ds3wryljalyj";
     };
   }
   {


### PR DESCRIPTION
Time for a bump of various dependencies to kubernixos.
This is just the github part. It won't update anything in the DBC deployments repo. That would be a separate MR.

Note: kubeval itself can't be upgraded easily, since it has converted to gomodules.
We should try and make kubernixos use go.mods as well.