### PR TITLE
Do less stuff on eval / dump

### DIFF
--- a/kubernixos.go
+++ b/kubernixos.go
@@ -126,6 +126,9 @@ func eval(outFile *os.File) (config *nix.Config, err error) {
 		json.Indent(&out, byteArr, "", "\t")
 		out.WriteTo(os.Stdout)
 		fmt.Println()
+	} else {
+		// Print the checksum only, if dump isn't requested
+		fmt.Println(config.Checksum)
 	}
 	return
 }

--- a/kubernixos.go
+++ b/kubernixos.go
@@ -34,23 +34,26 @@ func main() {
 	config, err := eval(deployFile)
 	fail("eval", err)
 
-	err = apply(deployFile, config, passthroughArgs)
-	fail("apply", err)
+	// non of the below steps should be taken if we're not in either apply or prune mode
+	if doApply || doPrune {
+		err = apply(deployFile, config, passthroughArgs)
+		fail("apply", err)
 
-	restConfig, err := kubeclient.GetKubeConfig(config.Server)
-	fail("kube-config", err)
+		restConfig, err := kubeclient.GetKubeConfig(config.Server)
+		fail("kube-config", err)
 
-	clients, err := kubeclient.GetKubeClient(restConfig)
-	fail("kube-client", err)
+		clients, err := kubeclient.GetKubeClient(restConfig)
+		fail("kube-client", err)
 
-	var types []kubeclient.ResourceType
-	types, err = kubeclient.GetResourceTypes(clients)
-	fail("resource-types", err)
+		var types []kubeclient.ResourceType
+		types, err = kubeclient.GetResourceTypes(clients)
+		fail("resource-types", err)
 
-	objects, err := kubeclient.GetResourcesToPrune(restConfig, config, types)
-	fail("all-resources", err)
+		objects, err := kubeclient.GetResourcesToPrune(restConfig, config, types)
+		fail("all-resources", err)
 
-	prune(objects, restConfig)
+		prune(objects, restConfig)
+	}
 }
 
 func fail(stage string, err error) {


### PR DESCRIPTION
Currently `kubernixos <deploy>` (eval) and `kubernixos <deploy> dump` results in kubernixos executing a dry-run prune, which means you can't get a clean JSON dump. It also means, that even when you just want a dump or a quiet eval, kubernixos will try to open a KUBECONFIG in your environment.

We don't want that. 
