### PR TITLE
Parse args with kingpin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,8 @@ This will mutate nothing.
 `kubernixos apply`: Like kubectl apply. This will apply kubernixos state to the cluster.
 Unwanted objects will not be pruned, unless "prune" is added to the command explicitly.
 
-`kubernixos prune`: This will prune unwanted objects from the cluster,
+`kubernixos apply --prune`: This will prune unwanted objects from the cluster,
 which are not part of the kubernixos nix closure.
-
-If `--show-trace` is passed to the kubernixos, this flag will be passed on to `nix eval`.
-
-If anything else is passed to kubernixos, these args will be forwarded to `kubectl apply`.
-This can be used to get more verbose kubectl output or perform a dry-run, e.g.: `kubernixos apply --dry-run=true -v=6`.
-
-Consecutive keywords can be passed to kubernixos, like `kubernixos dump apply prune`. 
 
 ## The module
 

--- a/default.nix
+++ b/default.nix
@@ -9,8 +9,7 @@ pkgs.buildGoModule rec {
   preBuild = ''
     ldflags+=" -X github.com/dbcdk/kubernixos/nix.root=$out/lib"
   ''; 
-
-  vendorSha256 = "sha256-d8PZ3RDd4c3kXxd9dwFX0ceHiDBtOYCNb19wY4yiUDg=";
+  vendorSha256 = "sha256-9ItzHm8kiP+CvXZTorPJfpYsQQ2P7bYt/m1RQ57PtHA=";
 
   postInstall = ''
     cp -rv $src/lib $out

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/dbcdk/kubernixos
 go 1.16
 
 require (
+	github.com/DBCDK/kingpin v2.2.6+incompatible
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
 	github.com/go-openapi/spec v0.19.3 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,11 +63,17 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DBCDK/kingpin v2.2.6+incompatible h1:T4yaG6VZFCtsp+2CzE7UFGkgoMECDNGaES90Uu3EbaQ=
+github.com/DBCDK/kingpin v2.2.6+incompatible/go.mod h1:bgEnLHzC+HvAA+6M6MS+GKXRdn9q6OOywZEb7pMYjKU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/kubernixos.go
+++ b/kubernixos.go
@@ -21,7 +21,6 @@ var (
 	dump      = parseDump(app.Command("dump", "Dump all kubernetes resources in manifest to stdout."))
 	apply     = parseApply(app.Command("apply", "Builds the manifest, applies resources to the cluster, then prunes old dpeloyments"))
 	build     = parseBuild(app.Command("build", "Returns a store-path with the kubernetes resources from the manifest."))
-	test      = parseBuild(app.Command("test", "test."))
 	manifest  string
 	doPrune   bool
 	showTrace bool


### PR DESCRIPTION
Use a library instead of parsing arguments by hand
This adds two nice features for free: --help and autocompletion.

I changed argument order from `kubernixos foo.nix command`
to `kubernixos command foo.nix, to follow other unix cli tools
conventions.