### PR TITLE
Selflink deprecated: construct from metadata.

### DIFF
--- a/kubeclient/types.go
+++ b/kubeclient/types.go
@@ -18,7 +18,9 @@ type Object struct {
 }
 
 type Metadata struct {
-	Labels   map[string]string `json:"labels"`
-	SelfLink string            `json:"selfLink"`
-	UID      string            `json:"uid"`
+	Labels        map[string]string `json:"labels"`
+	SelfLink      string            
+	UID           string            `json:"uid"`
+	Name          string            `json:"name"`
+	Namespace     string            `json:"namespace"`
 }


### PR DESCRIPTION
There's a test bed on the branch `selflink-deprecated-test`, that you can run with `kubernixos ../../k8s-stg.nix test`, it gives the following results, on our staging cluster: 

```
test done: 72/72 identical selflinks for apigroup: services .
test done: 138/138 identical selflinks for apigroup: namespaces
test done: 72/72 identical selflinks for apigroup: endpoints
test done: 50/50 identical selflinks for apigroup: configmaps
test done: 3/3 identical selflinks for apigroup: persistentvolumeclaims
test done: 159/159 identical selflinks for apigroup: serviceaccounts
test done: 28/28 identical selflinks for apigroup: limitranges
test done: 1/1 identical selflinks for apigroup: apiservices
test done: 19/19 identical selflinks for apigroup: statefulsets
test done: 50/50 identical selflinks for apigroup: deployments
test done: 11/11 identical selflinks for apigroup: cronjobs
test done: 31/31 identical selflinks for apigroup: ingresses
test done: 203/203 identical selflinks for apigroup: networkpolicies
test done: 27/27 identical selflinks for apigroup: poddisruptionbudgets
test done: 1/1 identical selflinks for apigroup: podsecuritypolicies
test done: 20/22 identical selflinks for apigroup: clusterroles
test done: 278/278 identical selflinks for apigroup: roles
test done: 279/279 identical selflinks for apigroup: rolebindings
test done: 22/24 identical selflinks for apigroup: clusterrolebindings
test done: 1/1 identical selflinks for apigroup: storageclasses
test done: 1/1 identical selflinks for apigroup: validatingwebhookconfigurations
test done: 1/1 identical selflinks for apigroup: mutatingwebhookconfigurations
test done: 3/3 identical selflinks for apigroup: customresourcedefinitions
test done: 10/10 identical selflinks for apigroup: priorityclasses 
test done: 72/72 identical selflinks for apigroup: endpointslices 
Result: 1552/1556 identical selflinks.


The four selflink that differ:

/apis/rbac.authorization.k8s.io/v1/clusterroles/system%3Aaggregated-metrics-reader != /apis/rbac.authorization.k8s.io/v1/clusterroles/system:aggregated-metrics-reader
/apis/rbac.authorization.k8s.io/v1/clusterroles/system%3Ametrics-server != /apis/rbac.authorization.k8s.io/v1/clusterroles/system:metrics-server
/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/metrics-server%3Asystem%3Aauth-delegator != /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/metrics-server:system:auth-delegator
/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system%3Ametrics-server != /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system:metrics-server
```

I don't think it matters if it's a valid IDN on the client-side, though? I can test this if reviewer is unsure about the change