### PR TITLE
nixpkgs 23.11 and change to vendorHash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ pkgs.buildGoModule rec {
     ldflags+=" -X github.com/dbcdk/kubernixos/nix.root=$out/lib"
   ''; 
 
-  vendorSha256 = "sha256-yaVpYhAfddW0INS+2lpjE5lYwo5K82qv74bM9WYAsGs=";
+  vendorHash = "sha256-yaVpYhAfddW0INS+2lpjE5lYwo5K82qv74bM9WYAsGs=";
 
   postInstall = ''
     cp -rv $src/lib $out

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-fetchTarball "https://github.com/NixOS/nixpkgs/archive/596a8e828c5dfa504f91918d0fa4152db3ab5502.tar.gz"
+fetchTarball "https://github.com/NixOS/nixpkgs/archive/01885a071465e223f8f68971f864b15829988504.tar.gz"


### PR DESCRIPTION
Gets rid of the warning with newer nixpkgs