### PR TITLE
support flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ pkgs.stdenv.mkDerivation {
 
 The above example wraps the kubernixos script such that it's first arg becomes
 a path to a network-file (similar to hostgroup files used by Morph or NixOps).
+
+
+## flakes
+
+There's also a --flake flag in the presence of which kubernixos will expect
+`KUBERNIXOS_ATTR` containing a string reference to an _evaluated_ kubernixos
+configuration, eg `myflakeref#myAttr.config.kubernixos`.
+
+This allows you to forgo any of the assumptions made by `lib/eval.nix`

--- a/kubernixos.go
+++ b/kubernixos.go
@@ -21,6 +21,7 @@ var (
 	doApply = false
 	doPrune = false
 	doDump  = false
+	flake  = false
 	nixArgs = make([]string, 0)
 )
 
@@ -54,7 +55,7 @@ func main() {
 	}
 
 	if doBuild || doApply || doPrune {
-		build, err := nix.Build("build", nixArgs)
+		build, err := build("build")
 		fail("build", err)
 		fmt.Println(build) // print outpath to stdout
 		inFile, err = os.Open(filepath.Join(build, "kubernixos.json"))
@@ -116,6 +117,9 @@ func parseArg(arg string) bool {
 	case "--show-trace":
 		nixArgs = append(nixArgs, arg)
 		return true
+	case "--flake":
+		flake = true
+		return true
 	case "--prune":
 		fmt.Fprintf(os.Stderr, "Usage of `kubectl apply --prune` is disabled in kubernixos\n")
 		os.Exit(1)
@@ -133,7 +137,7 @@ func apply(inFile *os.File, config *nix.Config, args []string) error {
 
 func read(attr string) (data map[string]map[string]interface{}, err error) {
 	var raw *bytes.Buffer
-	raw, err = nix.Eval(attr, nixArgs)
+	raw, err = eval(attr)
 	if err != nil {
 		return
 	}
@@ -147,7 +151,7 @@ func read(attr string) (data map[string]map[string]interface{}, err error) {
 
 func subread(attr string) (data map[string]interface{}, err error) {
 	var raw *bytes.Buffer
-	raw, err = nix.Eval(attr, nixArgs)
+	raw, err = eval(attr)
 	if err != nil {
 		return
 	}
@@ -230,5 +234,21 @@ func askForConfirmation() bool {
 	} else {
 		fmt.Print("Please type yes or no and then press enter: ")
 		return askForConfirmation()
+	}
+}
+
+func eval(attribute string) (*bytes.Buffer, error) {
+	if flake {
+		return nix.FlakeEval(attribute)
+	} else {
+		return nix.Eval(attribute, nixArgs)
+	}
+}
+
+func build(attribute string) (string, error) {
+	if flake {
+		return nix.FlakeBuild(attribute)
+	} else {
+		return nix.Build(attribute, nixArgs)
 	}
 }

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -43,6 +43,29 @@ func Eval(attribute string, args []string) (buffer *bytes.Buffer, err error) {
 	return
 }
 
+func FlakeEval(attribute string) (buffer *bytes.Buffer, err error) {
+	kubernixosAttr := os.Getenv("KUBERNIXOS_ATTR")
+	if kubernixosAttr == "" {
+		return nil, errors.New("KUBERNIXOS_ATTR must be set in environment")
+	}
+
+	// TODO: build the entire config instead of eval'ing, to get eval cache
+
+	nixArgs := make([]string, 0)
+	nixArgs = append(nixArgs, "eval")
+	nixArgs = append(nixArgs, "--json")
+	nixArgs = append(nixArgs, kubernixosAttr + "." + attribute)
+
+	cmd := exec.Command("nix", nixArgs...)
+
+	buffer = &bytes.Buffer{}
+	cmd.Stdout = buffer
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	return
+}
+
 func Build(attribute string, args []string) (path string, err error) {
 	kubernixosNix := filepath.Join(root, "eval.nix")
 
@@ -62,6 +85,28 @@ func Build(attribute string, args []string) (path string, err error) {
 	nixArgs = append(nixArgs, []string{"-o", "result-kubernixos"}...)
 	nixArgs = append(nixArgs, []string{"-f", kubernixosNix}...)
 	nixArgs = append(nixArgs, []string{attribute}...)
+	cmd := exec.Command("nix", nixArgs...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return os.Readlink("result-kubernixos")
+}
+
+func FlakeBuild(attribute string) (path string, err error) {
+	kubernixosAttr := os.Getenv("KUBERNIXOS_ATTR")
+	if kubernixosAttr == "" {
+		return "", errors.New("KUBERNIXOS_ATTR must be set in environment")
+	}
+
+	nixArgs := make([]string, 0)
+	nixArgs = append(nixArgs, "build")
+	nixArgs = append(nixArgs, []string{"-o", "result-kubernixos"}...)
+	nixArgs = append(nixArgs, kubernixosAttr + "." + attribute)
 	cmd := exec.Command("nix", nixArgs...)
 
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This allowsbuilding flakefully as specified in the README.

Rather preliminary as a better version would also change the expected kubernixos `.eval` module output outputs to drv which could be cached.